### PR TITLE
Add support for Kerbal Alarm Clock mod

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -211,6 +211,17 @@ Those steps get your vehicle ready (you may enclose them in a single script and 
 
 If something is going wrong mid-flight, you can use the standard action group `ABORT` to make PEGAS relinquish all control and exit.
 
+### Kerbal Alarm Clock support
+PEGAS can add a KAC alarm which will automatically kill time-warp ahead of liftoff. This means that you can safely speed up time and KAC will make sure that you won't overshoot and miss the launch time.
+
+To enable this feature, open the `pegas_settings.ks` file and set the `addKacAlarm` variable to `TRUE`. Additionally, you can specify how many seconds before liftoff the alarm should go off by changing the `kacAlarmAdvance` variable.
+
+The alarm is added as soon as pegas starts up and calculates the liftoff time. Once it adds the alarm, a message will appear on the terminal UI confirming that an alarm has been added to KAC. Once that message appears, you can sefaly initiate time-warp and KAC will handle stopping it at the right time. If KAC is not installed, the message will say that adding the alarm failed.
+
+KAC alarm will only be added if it will go off more than 5 seconds from the time it was set up. This means that if you left the `kacAlarmAdvance` as 30 seconds, an alarm will only be added if its over 35 seconds until liftoff. This is to avoid the alarm going off almost immediately after being created.
+
+Please note that this feature requires [Kerbal Alarm Clock](https://github.com/TriggerAu/KerbalAlarmClock/releases) mod to be installed.
+
 ##### Suspected bug in kOS
 Note that if you revert flight while controls are locked by kOS, the attempt to lock them again (in the new flight) will result in `object reference not set` error.
 When that happens you will have to leave and reenter the vehicle view.

--- a/kOS/addons/pegas_kac_integration.ks
+++ b/kOS/addons/pegas_kac_integration.ks
@@ -1,0 +1,25 @@
+// A PEGAS addon that adds support for Kerbal Alarm Clock mod.
+
+// Addon settings
+LOCAL alarmsEnabled IS TRUE.		//	Controls whether the addon is enabled. If you don't want PEGAS to add alarms, set this to FALSE.
+LOCAL kacAlarmAdvance IS 30.		//	Defines how many seconds before lift off the alarm should go off (30 seconds by default).
+
+//	Add alarm if requested
+FUNCTION addKacAlarm {
+	//	Make sure Kerbal Alarm Clock is installed before trying to add the alarm.
+	IF ADDONS:AVAILABLE("KAC") {
+		//	Only add the alarm if it will go off more that 5 seconds from now. Otherwise it's not really needed.
+		IF liftoffTime - kacAlarmAdvance > currentTime + 5 {
+			ADDALARM("Raw", liftoffTime:SECONDS - kacAlarmAdvance, "Launch Alarm", SHIP:NAME + " is launching in " + kacAlarmAdvance + " seconds.").
+			pushUIMessage("Alarm added to KAC.").
+		}
+	} ELSE {
+		//	If KAC is not available, display a UI message
+		pushUIMessage("Failed to add KAC alarm! KAC not installed.").
+	}
+}
+
+// If alarms are enabled, register this addon with PEGAS in the initiation phase
+IF alarmsEnabled {
+	register_hook(addKacAlarm@, "init").
+}

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -48,20 +48,6 @@ SET currentTime TO TIME.
 SET timeToOrbitIntercept TO orbitInterceptTime().
 GLOBAL liftoffTime IS currentTime + timeToOrbitIntercept - controls["launchTimeAdvance"].
 IF timeToOrbitIntercept < controls["launchTimeAdvance"] { SET liftoffTime TO liftoffTime + SHIP:BODY:ROTATIONPERIOD. }
-//	Add alarm if requested
-IF addKacAlarm {
-	//	Make sure Kerbal Alarm Clock is installed before trying to add the alarm.
-	IF ADDONS:AVAILABLE("KAC") {
-		//	Only add the alarm if it will go off more that 5 seconds from now. Otherwise it's not really needed.
-		IF liftoffTime - kacAlarmAdvance > currentTime + 5 {
-			ADDALARM("Raw", liftoffTime:SECONDS - kacAlarmAdvance, "Launch Alarm", SHIP:NAME + " is launching in " + kacAlarmAdvance + " seconds.").
-			pushUIMessage("Alarm added to KAC.").
-		}
-	} ELSE {
-		//	If KAC is not available, display a UI message
-		pushUIMessage("Failed to add KAC alarm! KAC not installed.").
-	}
-}
 //	Calculate launch azimuth if not specified
 IF NOT mission:HASKEY("launchAzimuth") {
 	mission:ADD("launchAzimuth", launchAzimuth()).

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -48,6 +48,20 @@ SET currentTime TO TIME.
 SET timeToOrbitIntercept TO orbitInterceptTime().
 GLOBAL liftoffTime IS currentTime + timeToOrbitIntercept - controls["launchTimeAdvance"].
 IF timeToOrbitIntercept < controls["launchTimeAdvance"] { SET liftoffTime TO liftoffTime + SHIP:BODY:ROTATIONPERIOD. }
+//	Add alarm if requested
+IF addKacAlarm {
+	//	Make sure Kerbal Alarm Clock is installed before trying to add the alarm.
+	IF ADDONS:AVAILABLE("KAC") {
+		//	Only add the alarm if it will go off more that 5 seconds from now. Otherwise it's not really needed.
+		IF liftoffTime - kacAlarmAdvance > currentTime + 5 {
+			ADDALARM("Raw", liftoffTime:SECONDS - kacAlarmAdvance, "Launch Alarm", SHIP:NAME + " is launching in " + kacAlarmAdvance + " seconds.").
+			pushUIMessage("Alarm added to KAC.").
+		}
+	} ELSE {
+		//	If KAC is not available, display a UI message
+		pushUIMessage("Failed to add KAC alarm! KAC not installed.").
+	}
+}
 //	Calculate launch azimuth if not specified
 IF NOT mission:HASKEY("launchAzimuth") {
 	mission:ADD("launchAzimuth", launchAzimuth()).

--- a/kOS/pegas_settings.ks
+++ b/kOS/pegas_settings.ks
@@ -8,3 +8,5 @@ GLOBAL upfgFinalizationTime IS 5.		//	When time-to-go gets below that, keep atti
 GLOBAL stagingKillRotTime IS 5.			//	Updating attitude commands will be forbidden that many seconds before staging (in an attempt to keep vehicle steady for a clean separation).
 GLOBAL upfgConvergenceCriterion IS 0.1.	//	Maximum difference between consecutive UPFG T-go predictions that allow accepting the solution.
 GLOBAL upfgGoodSolutionCriterion IS 15.	//	Maximum angle between guidance vectors calculated by UPFG between stages that allow accepting the solution.
+GLOBAL addKacAlarm IS FALSE.			//	Adds a new alarm to Kerbal Alarm Clock mod (if installed) which kills timewarp ahead of liftoff.
+GLOBAL kacAlarmAdvance IS 30.			//	Defines how many seconds before lift off the alarm should go off (30 seconds by default).

--- a/kOS/pegas_settings.ks
+++ b/kOS/pegas_settings.ks
@@ -8,5 +8,3 @@ GLOBAL upfgFinalizationTime IS 5.		//	When time-to-go gets below that, keep atti
 GLOBAL stagingKillRotTime IS 5.			//	Updating attitude commands will be forbidden that many seconds before staging (in an attempt to keep vehicle steady for a clean separation).
 GLOBAL upfgConvergenceCriterion IS 0.1.	//	Maximum difference between consecutive UPFG T-go predictions that allow accepting the solution.
 GLOBAL upfgGoodSolutionCriterion IS 15.	//	Maximum angle between guidance vectors calculated by UPFG between stages that allow accepting the solution.
-GLOBAL addKacAlarm IS FALSE.			//	Adds a new alarm to Kerbal Alarm Clock mod (if installed) which kills timewarp ahead of liftoff.
-GLOBAL kacAlarmAdvance IS 30.			//	Defines how many seconds before lift off the alarm should go off (30 seconds by default).


### PR DESCRIPTION
Adds feature from #21 

Like I said in the comment, this only works if KAC is installed. If KAC is not installed and user want's to add an alarm, it will just push a UI message saying "Failed to add KAC alarm! KAC not installed.".

The nice thing is that it doesn't seem to be possible to warp past the alarm unless you are still mashing the time-warp button after the alarm has gone off.