### PR TITLE
Adding a new ascent mode to PEGAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Change log
 
+## [v1.2](https://github.com/Aram1d/PEGAS/releases/tag/v1.2) (2020-18-11)
+
+##### Features:
+*  Implementation of a new initial ascent guidance using linear regression.
+
 ## [v1.1](https://github.com/Noiredd/PEGAS/releases/tag/v1.1) (2017-11-05)
 Multiple fixes for bugs identified after the initial release and new features requested since.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,16 +7,30 @@ Variable of type `LEXICON`.
 Defines vehicle behavior in phases 0 and 1 (pre-launch and atmospheric ascent).
 List of possible keys:
 
-Key                | Units | Opt/req  | Meaning
----                | ---   | ---      | ---
-launchTimeAdvance  | s     | required | Launch time will be scheduled that many seconds before the launch site rotates directly under the target orbit
-verticalAscentTime | s     | required | After liftoff, vehicle will fly straight up for that many seconds before pitching over
-pitchOverAngle     | deg   | required | Vehicle will pitch over by that many degrees away from vertical
-upfgActivation     | s     | required | The active guidance phase will be activated that many seconds after liftoff
-launchAzimuth      | deg   | optional | Overrides automatic launch azimuth calculation, giving some basic optimization capability\*
-initialRoll        | deg   | optional | Angle to which the vehicle will roll during the initial pitchover maneuver (default is 0)
+Key                | Units      | Opt/req  | Meaning
+---                | ---        | ---      | ---
+launchTimeAdvance  | s          | required | Launch time will be scheduled that many seconds before the launch site rotates directly under the target orbit
+verticalAscentTime | s          | required | After liftoff, vehicle will fly straight up for that many seconds before pitching over
+pitchOverAngle     | deg        | Optional** | Vehicle will pitch over by that many degrees away from vertical
+pitchStartAlt      | m          | Optional** | After liftoff, vehicle will fly straight up until this altitude.
+pitchControl       | `List`  | Optional** | A set of pitch angles & altitude pairs
+upfgActivation     | s          | required | The active guidance phase will be activated that many seconds after liftoff
+launchAzimuth      | deg        | optional | Overrides automatic launch azimuth calculation, giving some basic optimization capability\*
+initialRoll        | deg        | optional | Angle to which the vehicle will roll during the initial pitchover maneuver (default is 0)
 
 \* - see notes to [`mission`](#mission) struct.
+\*\* - Of the four fields, only 2 have to be provided: First solution is to provide `verticalAscentTime` with `pitchOverAngle`. The rocket will flight Straight up until `verticalAscentTime` seconds, then pitch `pitchOverAngle` angle that would be followed until the rocket track the prograde vector; Second solution is to use `pitchStartAlt` with `pitchControl` is used to further control your initial ascent phase, as described in the bellow [`pitchControl`](#pitchControl) section.
+
+#### pitchControl
+Key of type `LIST` containing `LEXICON`s. `pitchControl` allow you to completely control your atmospheric ascent phase by setting the pitch angle as a linear function of the ASL altitude. Linear regression is made from 90 degrees (which corresponds to straight up) to a specified ending angle, with altitude starting as `pitchStartAlt`. PEGAS make the linear regression for you and lock the pitch to (a * Alt + b).
+
+As `pitchControl` is a `LIST`, you can set more than one  pitch/Alt pairs, so that PEGAS will make another linear regression using the previous end values as initial ones for the new segment. Multiple pairs of data can be  chained, but remember it's your responsibility to keep them consistent().
+
+`pitchControl` 's `LEXICON` follow these rules:
+
+Key             | Type/units | Opt/req   | Meaning
+"endAlt"        | m          | required  | The altitude in which the `endPitch` angle will be reached
+"endPitch"      | deg        | required  | The pitch angle that will be observed when reaching the paired `endAlt`
 
 ### Vehicle
 `GLOBAL vehicle IS LIST().`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -81,6 +81,12 @@ Getting it perfect (so that the UPFG-generated pitch matches prograde) might tur
 Tuning those variables might prove particularly difficult if you're getting low ingame FPS during liftoff, or your launch clamps misbehave.
 Unpredictable separation that disrupts your vehicle from flying straight can even make a good settings randomly fail. Beware.
 
+#####  `pitchStartAlt` and `pitchControl`
+For some vessels the above solution (with `verticalAscentTime` and `pitchOverAngle`) do not give enough controllability. PEGAS provides now a new solution to guide your vehicles with more accuracy for the atmospheric climb.
+You simply gives an altitude from which the rocket will start the pitch maneuver (from 90 deg, since your rocket always liftoff from vertical position). Then you pass a couple of altitude/pitchAngle to `pitchControl` so that PEGAS
+makes a linear regression and formulates pitch function of altitude. `pitchControl` can receive multiple altitude/pitchAngle pairs, it will make multiple segments according to their values and each segment will be driver by a linear regression.
+Like the other solution, this one require that you know your rocket to define at least one set of value. for more informations see [pitchControl](references.md#pitchControl)
+
 ##### upfgActivation
 This is when the atmospheric ascent ends, and active guidance begins.
 You want to be outside the atmosphere when that happens, 40-50 km is good.

--- a/examples/SoyouzTMA.ks
+++ b/examples/SoyouzTMA.ks
@@ -1,0 +1,46 @@
+GLOBAL vehicle IS LIST (
+  LEXICON(
+    //THIRD STAGE WITH RD-0124
+    "name", "R7, RD-0124 Thrd. Stage",
+    "massTotal", 16772,
+    "massFuel", 3105+3800,
+    "engines", LIST(LEXICON("isp", 330, "thrust", 148000)),
+    "staging", LEXICON(
+      "jettison", false,
+      "ignition", false
+    )
+  )
+).
+
+
+
+GLOBAL controls IS LEXICON(
+  "launchTimeAdvance", 140,
+  "upfgActivation", 156,
+  "pitchStartAlt", 200,
+  "pitchControl", LIST(LEXICON("endAlt", 20000, "endPitch", 45), LEXICON("endAlt", 65000, "endPitch", 0))
+
+).
+
+//Set time (in s) between ignition and liftoff here
+Set IgnTime TO 2.
+
+ GLOBAL sequence IS LIST(
+   LEXICON("time", -IgnTime, "type", "stage", "message", "Ignition !"),
+   LEXICON("time", 0, "type", "stage", "message", "Liftoff !"),
+   LEXICON("time", 70-IgnTime, "type", "stage", "message", "LES tower Ejected!" ), //"massLost", 2162,
+   LEXICON("time", 77-IgnTime, "type", "stage", "message", "First Stage is ejecting"),
+   LEXICON("time", 78-IgnTime, "type", "stage", "message", "First Stage is ejected" ),
+   LEXICON("time", 100-IgnTime, "type", "stage", "message", "Fairings Ejected"), //"massLost", 3200,
+   LEXICON("time", 153-IgnTime, "type", "stage", "message", "Third Stage Ignition" ),
+   LEXICON("time", 154-IgnTime, "type", "stage", "message", "Second Stage ejection" )
+).
+
+GLOBAL mission is LEXICON(
+  "apoapsis", 72,
+  "periapsis", 72,
+  "inclination", 51.65
+).
+
+CLEARSCREEN.
+PRINT "Loaded boot file: Soyouz TMA".

--- a/kOS/pegas_misc.ks
+++ b/kOS/pegas_misc.ks
@@ -19,7 +19,7 @@ SET TERMINAL:HEIGHT TO 26 + 14.	//	Few more lines for debugging
 FUNCTION createUI {
 	CLEARSCREEN.
 	PRINT ".-----------------------------------------.".
-	PRINT "| PEGAS                              v1.1 |".
+	PRINT "| PEGAS                              v1.2 |".
 	PRINT "| Powered Explicit Guidance Ascent System |".
 	PRINT "|-----------------------------------------|".
 	PRINT "| T   h  m  s |                           |".
@@ -43,7 +43,7 @@ FUNCTION createUI {
 	PRINT "|-----------------------------------------|".
 	PRINT "|                                         |".
 	PRINT "*-----------------------------------------*".
-	
+
 	textPrint(SHIP:NAME, 6, 2, 41, "L").
 	refreshUI().
 }
@@ -55,7 +55,7 @@ FUNCTION textPrint {
 	DECLARE PARAMETER start.		//	First column to write to, inclusive (scalar).
 	DECLARE PARAMETER end.			//	Last column to write to, exclusive (scalar).
 	DECLARE PARAMETER align IS "l".	//	Align: "l"eft or "r"ight.
-	
+
 	SET align TO align:TOLOWER().
 	LOCAL flen IS end - start.
 	//	If message is too long to fit in the field - trim, depending on type.
@@ -78,7 +78,7 @@ FUNCTION numberPrint {
 	DECLARE PARAMETER end.			//	Last column to write to, exclusive (scalar).
 	DECLARE PARAMETER prec IS 1.	//	Decimal places (scalar)
 	DECLARE PARAMETER align IS "r".	//	Align: "l"eft or "r"ight.
-	
+
 	LOCAL str IS "" + ROUND(val, prec).
 	//	Make sure the number has all the decimal places it needs to have
 	IF prec > 0 {
@@ -95,7 +95,7 @@ FUNCTION numberPrint {
 //	Specialized function for printing current time and T+.
 FUNCTION timePrint {
 	//	Expects a global variable "liftoffTime" as timespan.
-	
+
 	LOCAL currentTime IS TIME.
 	LOCAL deltaT IS currentTime.
 	LOCAL sign IS "".
@@ -106,14 +106,14 @@ FUNCTION timePrint {
 		SET sign TO "-".
 		SET deltaT TO liftoffTime - currentTime.
 	}
-	
+
 	textPrint(sign, 4, 3, 4, "L").
 	numberPrint(deltaT:HOUR, 4, 4, 6, 0).
 	numberPrint(deltaT:MINUTE, 4, 7, 9, 0).
 	numberPrint(deltaT:SECOND, 4, 10, 12, 0).
 	textPrint(currentTime:CALENDAR+",", 4, 15, 32, "R").
 	textPrint(currentTime:CLOCK, 4, 33, 41, "R").
-	
+
 	RETURN currentTime.
 }
 
@@ -122,14 +122,14 @@ FUNCTION refreshUI {
 	//	Expects global variables "liftoffTime" as timespan, "throttleSetting" as scalar, "controls", "mission", "upfgTarget" and "upfgInternal" as lexicon and "upfgConverged" as bool.
 
 	LOCAL currentTime IS timePrint().
-	
+
 	//	Section offsets, for easier extendability
 	LOCAL vehicleInfoOffset IS 8.	//	Reads: vehicle info section starts at row 8
 	LOCAL orbitalInfoOffset IS 14.
 	LOCAL currentOrbitOffset IS 15.	//	Horizontal offset for the current orbit info
 	LOCAL targetOrbitOffset IS 29.	//	Horizontal offset for the target orbit info
 	LOCAL messageBoxOffset IS 23.
-	
+
 	//	First figure out what phase of the flight are we in: passively or actively guided.
 	IF NOT (DEFINED upfgInternal) {
 		//	Don't try to access any UPFG-related variables
@@ -165,13 +165,13 @@ FUNCTION refreshUI {
 			numberPrint(timeToNextStage, vehicleInfoOffset, 35, 39, 0).
 		} ELSE { textPrint("", vehicleInfoOffset, 9, 33). }
 	}
-	
+
 	//	Print physical information
 	LOCAL throttle_ IS throttleDisplay.
 	LOCAL currentAcc IS (SHIP:AVAILABLETHRUST * throttle_) / (SHIP:MASS).
 	numberPrint(100*throttle_, vehicleInfoOffset + 2, 17, 21, 0).
 	numberPrint(currentAcc, vehicleInfoOffset + 3, 17, 21).
-	
+
 	//	Print current vehicle state
 	numberPrint(SHIP:ALTITUDE/1000,			orbitalInfoOffset + 0, currentOrbitOffset, currentOrbitOffset + 7).
 	numberPrint(SHIP:VERTICALSPEED,			orbitalInfoOffset + 2, currentOrbitOffset, currentOrbitOffset + 7).
@@ -179,7 +179,7 @@ FUNCTION refreshUI {
 	numberPrint(SHIP:ORBIT:APOAPSIS/1000,	orbitalInfoOffset + 4, currentOrbitOffset, currentOrbitOffset + 7).
 	numberPrint(SHIP:ORBIT:INCLINATION,		orbitalInfoOffset + 5, currentOrbitOffset, currentOrbitOffset + 7, 2).
 	numberPrint(SHIP:ORBIT:LAN,				orbitalInfoOffset + 6, currentOrbitOffset, currentOrbitOffset + 7, 2).
-	
+
 	//	Print target state
 	numberPrint(mission["altitude"],		orbitalInfoOffset + 0, targetOrbitOffset, targetOrbitOffset + 7).
 	numberPrint(upfgTarget["velocity"],		orbitalInfoOffset + 1, targetOrbitOffset, targetOrbitOffset + 7).
@@ -188,12 +188,12 @@ FUNCTION refreshUI {
 	numberPrint(mission["apoapsis"],		orbitalInfoOffset + 4, targetOrbitOffset, targetOrbitOffset + 7).
 	numberPrint(mission["inclination"],		orbitalInfoOffset + 5, targetOrbitOffset, targetOrbitOffset + 7, 2).
 	numberPrint(mission["LAN"],				orbitalInfoOffset + 6, targetOrbitOffset, targetOrbitOffset + 7, 2).
-	
+
 	//	Calculate and print angle between orbits
 	LOCAL currentOrbitNormal IS targetNormal(SHIP:ORBIT:INCLINATION, SHIP:ORBIT:LAN).
 	LOCAL relativeAngle IS VANG(currentOrbitNormal, upfgTarget["normal"]).
 	numberPrint(relativeAngle, orbitalInfoOffset + 7, 24, 29, 2).
-	
+
 	//	Handle messages
 	IF uiMessage["received"] {
 		//	If we have any message
@@ -221,7 +221,7 @@ FUNCTION pushUIMessage {
 	DECLARE PARAMETER message.		//	Expects a string.
 	DECLARE PARAMETER ttl IS 5.		//	Message time-to-live (scalar).
 	DECLARE PARAMETER priority IS PRIORITY_NORMAL.
-	
+
 	//	If we already have a message - only accept the new one if it's important enough
 	IF uiMessage["received"] {
 		IF priority >= uiMessage["priority"] {


### PR DESCRIPTION
Hi,

I had some problems with using PEGAS on my SOYUZ rocket:

The initial ascent mode using a single pitch angle followed after an amount of time to then track the prograde vector was not sucessful on my craft, it swings a lot betweens the different steps, and  I could'nt find a pair of values working good enough to get at set of data (initial position and velocity) that UPFG could easily manage when it triggers.

That's why I coded some new routine locking the pitch angle as a linear function of altitude. You can use multiple linear regression, just give their beginning and ending altitudes and the specific pitch values for them.

You can have a look to the extended documentation i wrote for more details, and i keep available for questions.

Thanks, Wilfried 