### PR TITLE
Events system overhaul

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ When UPFG kicks in, it tries to correct for that drift by aiming more towards we
 Sometimes it can recover from that, other times not - but the more *late* the launch was, the more performance degradation this causes; eventually, vehicle might not have enough fuel to make it to orbit.
 Similar situation occurs if the launch was timed too early - UPFG points the vehicle more to the east, to make it *catch up* with the target plane, wasting fuel in the same manner.  
 This is a difficult parameter to get right, but fortunately as long as you're in a reasonable range, it only hinders performance (instead of causing critical failures).
-Experimentally, I found times of 120-150 seconds to work good.
+Experimentally, I found that times on the order of 120-150 seconds work well.
 Vehicles that reach orbit faster will need less advance time, while those long burning upper stages might use more.
 
 ##### verticalAscentTime and pitchOverAngle
@@ -93,7 +93,7 @@ Unpredictable separation that disrupts your vehicle from flying straight can eve
 This is when the atmospheric ascent ends, and active guidance begins.
 You want to be outside the atmosphere when that happens, 40-50 km is good.
 From this moment the UPFG is in control over your vehicle, and if you're too low and it decides to pitch up too much, you might experience your vehicle tumbling out of control for a moment, or even rapidly disassembling.
-It's not possible to provide example numbers, as this variable strongly depends on your vehicle - see the [boot files](kOS/boot).
+It's difficult to provide example numbers, as this variable strongly depends on your vehicle - see the [boot files](kOS/boot).
 
 ##### Rolling
 Roll control in PEGAS is achieved using two mechanisms.
@@ -173,11 +173,12 @@ This is how you control timed events, like:
 * separation of the strap-on boosters,
 * jettisoning the payload fairing,
 * rolling to given attitude,
-* throttle (only in the atmospheric ascent phase)\*,
-* shutdown of a specific engine,
+* throttle (only in the atmospheric ascent phase),
+* shutdown of a specific engine (by tag),
 * execution of custom functions (kOS [delegates](http://ksp-kos.github.io/KOS_DOC/language/delegates.html)).
 
-See the reference to all possible events and how to use them.  
+See the [reference](reference.md#sequence) for a list all possible events and how to use them.
+
 As you see, both `sequence` and `vehicle` can cause a staging (equivalent to hitting spacebar).
 The main difference between `vehicle` staging and `sequence`, is that vehicle staging events are bound to the *physical parameters of the vehicle* (how much fuel does a stage have, how fast does it consume it => when does the next stage activate), while `sequence` events are bound directly to time (counted from lift-off).
 For this reason, you must pay attention that your timed events be properly aligned in the in-game staging sequence, with respect to the staging events.
@@ -187,10 +188,8 @@ Recommended approach is to avoid scheduling other staging events near the main v
 One unique thing about sequence is that it controls the lift-off too.
 You **need to** have an entry at time zero that releases the launch clamps.
 
-\* - this hasn't yet been tested.
-
 ##### Note about delegate events
-If like to organize your code into boot files with vehicle configs and mission scripts with target parameters, you will run into a problem that's well explained in [this section](https://ksp-kos.github.io/KOS_DOC/structures/misc/kosdelegate.html#attribute:KOSDELEGATE:ISDEAD) of kOS documentation.
+If you like to organize your code into boot files with vehicle configs and mission scripts with target parameters, you will run into a problem that's well explained in [this section](https://ksp-kos.github.io/KOS_DOC/structures/misc/kosdelegate.html#attribute:KOSDELEGATE:ISDEAD) of kOS documentation.
 In short, a delegate only lives as long as the script that it comes from.
 After you've dropped out of that script, the delegate is "dead" (`KOSDelegate:ISDEAD`) and any attempt to call it will **error out** the kOS interpreter.
 This means you should define all delegates you want to execute via `sequence` in the same script that starts PEGAS (`RUN pegas.`).

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -24,7 +24,6 @@ SET CONFIG:IPU TO kOS_IPU.
 GLOBAL upfgStage IS -1.				//	System initializes at passive guidance
 GLOBAL stageEndTime IS TIME.		//	For Tgo calculation during active guidance (global time)
 GLOBAL eventPointer IS -1.			//	Index of the last executed event (-1 means none yet)
-GLOBAL commsEventFlag IS FALSE.
 GLOBAL throttleSetting IS 1.		//	This is what actually controls the throttle,
 GLOBAL throttleDisplay IS 1.		//	and this is what to display on the GUI - see throttleControl() for details.
 GLOBAL steeringVector IS LOOKDIRUP(SHIP:FACING:FOREVECTOR, SHIP:FACING:TOPVECTOR).
@@ -60,7 +59,6 @@ IF controls:HASKEY("initialRoll") {
 }
 //	Set up the system for flight
 setVehicle().			//	Complete vehicle definition (as given by user)
-setComms(). 			//	Setting up communications
 callHooks("init").		//	System initialized, run hooks
 
 
@@ -74,9 +72,10 @@ SET ascentFlag TO 0.	//	0 = vertical, 1 = pitching over, 2 = notify about holdin
 UNTIL ABORT {
 	//	User hooks
 	callHooks("passivePre").
-	//	Sequence handling
+	//	Event handling
 	eventHandler().
-	IF  commsEventFlag = TRUE {  commsEventHandler(). }
+	//	Communication system handling
+	commsHandler().
 	//	Control handling
 	IF ascentFlag = 0 {
 		//	The vehicle is going straight up for given amount of time
@@ -143,7 +142,8 @@ UNTIL ABORT {
 	callHooks("activePre").
 	//	Event handling
 	eventHandler().
-	IF  commsEventFlag = TRUE {  commsEventHandler(). }
+	//	Communication system handling
+	commsHandler().
 	//	Update UPFG target and vehicle state
 	SET upfgTarget["normal"] TO targetNormal(mission["inclination"], mission["LAN"]).
 	SET upfgState TO acquireState().

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -62,6 +62,7 @@ IF controls:HASKEY("initialRoll") {
 }
 //	Set up the system for flight
 setVehicle().			//	Complete vehicle definition (as given by user)
+spawnCountdownEvents().
 callHooks("init").		//	System initialized, run hooks
 
 

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -20,8 +20,8 @@ RUN pegas_addons.
 SET CONFIG:IPU TO kOS_IPU.
 
 //	Initialize global flags and constants
-GLOBAL upfgStage IS -1.				//	Seems wrong (we use "vehicle[upfgStage]") but first run of stageEventHandler increments this automatically
-GLOBAL stageEventFlag IS FALSE.
+GLOBAL upfgStage IS -1.				//	System initializes at passive guidance
+GLOBAL stageEndTime IS TIME.		//	For Tgo calculation during active guidance (global time)
 GLOBAL userEventPointer IS -1.		//	Index of the last executed userEvent (-1 means none yet)
 GLOBAL commsEventFlag IS FALSE.
 GLOBAL throttleSetting IS 1.		//	This is what actually controls the throttle,

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -28,8 +28,11 @@ GLOBAL throttleSetting IS 1.		//	This is what actually controls the throttle,
 GLOBAL throttleDisplay IS 1.		//	and this is what to display on the GUI - see throttleControl() for details.
 GLOBAL steeringVector IS LOOKDIRUP(SHIP:FACING:FOREVECTOR, SHIP:FACING:TOPVECTOR).
 GLOBAL steeringRoll IS 0.
-GLOBAL upfgConverged IS FALSE.
-GLOBAL stagingInProgress IS FALSE.
+GLOBAL activeGuidanceMode IS FALSE.	//	Set to TRUE at UPFG activation time (as defined in controls)
+GLOBAL upfgConverged IS FALSE.		//	See upfgSteeringControl comments
+GLOBAL upfgEngaged IS FALSE.		//	See upfgSteeringControl comments
+GLOBAL stagingInProgress IS FALSE.	//	See upfgSteeringControl comments
+GLOBAL prestageHold IS FALSE.		//	See upfgSteeringControl comments
 
 //	Load user addons
 scanAddons().
@@ -150,7 +153,7 @@ UNTIL ABORT {
 	//	Iterate UPFG and preserve its state
 	SET upfgInternal TO upfgSteeringControl(vehicle, upfgStage, upfgTarget, upfgState, upfgInternal).
 	//	Manage throttle, with the exception of initial portion of guided flight (where we're technically still flying the first stage).
-	IF upfgStage >= 0 { throttleControl(). }
+	IF activeGuidanceMode { throttleControl(). }
 	//	Transition to the attitude hold mode for the final seconds of the flight
 	IF upfgConverged AND upfgInternal["tgo"] < upfgFinalizationTime { BREAK. }
 	//	UI

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -58,7 +58,6 @@ IF controls:HASKEY("initialRoll") {
 	SET steeringRoll TO controls["initialRoll"].
 }
 //	Set up the system for flight
-setUserEvents().		//	Initialize vehicle sequence
 setVehicle().			//	Complete vehicle definition (as given by user)
 setComms(). 			//	Setting up communications
 callHooks("init").		//	System initialized, run hooks
@@ -143,7 +142,6 @@ UNTIL ABORT {
 	callHooks("activePre").
 	//	Sequence handling
 	userEventHandler().
-	IF  stageEventFlag = TRUE {  stageEventHandler(). }
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Update UPFG target and vehicle state
 	SET upfgTarget["normal"] TO targetNormal(mission["inclination"], mission["LAN"]).

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -22,9 +22,6 @@ SET CONFIG:IPU TO kOS_IPU.
 //	Initialize global flags and constants
 GLOBAL upfgStage IS -1.				//	Seems wrong (we use "vehicle[upfgStage]") but first run of stageEventHandler increments this automatically
 GLOBAL stageEventFlag IS FALSE.
-GLOBAL systemEvents IS LIST().
-GLOBAL systemEventPointer IS -1.	//	Same deal as with "upfgStage"
-GLOBAL systemEventFlag IS FALSE.
 GLOBAL userEventPointer IS -1.		//	As above
 GLOBAL userEventFlag IS FALSE.
 GLOBAL commsEventFlag IS FALSE.
@@ -62,7 +59,6 @@ IF controls:HASKEY("initialRoll") {
 	SET steeringRoll TO controls["initialRoll"].
 }
 //	Set up the system for flight
-setSystemEvents().		//	Set up countdown messages
 setUserEvents().		//	Initialize vehicle sequence
 setVehicle().			//	Complete vehicle definition (as given by user)
 setComms(). 			//	Setting up communications
@@ -80,7 +76,6 @@ UNTIL ABORT {
 	//	User hooks
 	callHooks("passivePre").
 	//	Sequence handling
-	IF systemEventFlag = TRUE { systemEventHandler(). }
 	IF   userEventFlag = TRUE {   userEventHandler(). }
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Control handling
@@ -148,7 +143,6 @@ UNTIL ABORT {
 	//	User hooks
 	callHooks("activePre").
 	//	Sequence handling
-	IF systemEventFlag = TRUE { systemEventHandler(). }
 	IF   userEventFlag = TRUE {   userEventHandler(). }
 	IF  stageEventFlag = TRUE {  stageEventHandler(). }
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -10,6 +10,7 @@ IF cserVersion = "new" {
 } ELSE {
 	RUN pegas_cser.
 }
+RUN pegas_events.
 RUN pegas_upfg.
 RUN pegas_util.
 RUN pegas_misc.
@@ -22,7 +23,7 @@ SET CONFIG:IPU TO kOS_IPU.
 //	Initialize global flags and constants
 GLOBAL upfgStage IS -1.				//	System initializes at passive guidance
 GLOBAL stageEndTime IS TIME.		//	For Tgo calculation during active guidance (global time)
-GLOBAL userEventPointer IS -1.		//	Index of the last executed userEvent (-1 means none yet)
+GLOBAL eventPointer IS -1.			//	Index of the last executed event (-1 means none yet)
 GLOBAL commsEventFlag IS FALSE.
 GLOBAL throttleSetting IS 1.		//	This is what actually controls the throttle,
 GLOBAL throttleDisplay IS 1.		//	and this is what to display on the GUI - see throttleControl() for details.
@@ -74,7 +75,7 @@ UNTIL ABORT {
 	//	User hooks
 	callHooks("passivePre").
 	//	Sequence handling
-	userEventHandler().
+	eventHandler().
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Control handling
 	IF ascentFlag = 0 {
@@ -140,8 +141,8 @@ callHooks("activeInit").
 UNTIL ABORT {
 	//	User hooks
 	callHooks("activePre").
-	//	Sequence handling
-	userEventHandler().
+	//	Event handling
+	eventHandler().
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Update UPFG target and vehicle state
 	SET upfgTarget["normal"] TO targetNormal(mission["inclination"], mission["LAN"]).

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -22,8 +22,7 @@ SET CONFIG:IPU TO kOS_IPU.
 //	Initialize global flags and constants
 GLOBAL upfgStage IS -1.				//	Seems wrong (we use "vehicle[upfgStage]") but first run of stageEventHandler increments this automatically
 GLOBAL stageEventFlag IS FALSE.
-GLOBAL userEventPointer IS -1.		//	As above
-GLOBAL userEventFlag IS FALSE.
+GLOBAL userEventPointer IS -1.		//	Index of the last executed userEvent (-1 means none yet)
 GLOBAL commsEventFlag IS FALSE.
 GLOBAL throttleSetting IS 1.		//	This is what actually controls the throttle,
 GLOBAL throttleDisplay IS 1.		//	and this is what to display on the GUI - see throttleControl() for details.
@@ -76,7 +75,7 @@ UNTIL ABORT {
 	//	User hooks
 	callHooks("passivePre").
 	//	Sequence handling
-	IF   userEventFlag = TRUE {   userEventHandler(). }
+	userEventHandler().
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Control handling
 	IF ascentFlag = 0 {
@@ -143,7 +142,7 @@ UNTIL ABORT {
 	//	User hooks
 	callHooks("activePre").
 	//	Sequence handling
-	IF   userEventFlag = TRUE {   userEventHandler(). }
+	userEventHandler().
 	IF  stageEventFlag = TRUE {  stageEventHandler(). }
 	IF  commsEventFlag = TRUE {  commsEventHandler(). }
 	//	Update UPFG target and vehicle state

--- a/kOS/pegas_comm.ks
+++ b/kOS/pegas_comm.ks
@@ -1,14 +1,11 @@
 //	Communication system functions
 
-//	Setup a trigger listening for mesages from other CPUs
-FUNCTION setComms {
-	WHEN NOT CORE:MESSAGES:EMPTY THEN {
-		SET commsEventFlag TO TRUE.
-	}
-}
-
 //	Handles communication with other CPUs
-FUNCTION commsEventHandler {
+FUNCTION commsHandler {
+	//	Only run if the message queue is not empty
+	IF CORE:MESSAGES:EMPTY {
+		RETURN.
+	}
 	//	Get the oldest message in the queue but don't delete it yet
 	LOCAL message IS CORE:MESSAGES:PEEK:CONTENT.
 	//	Create a response lexicon to send back
@@ -94,17 +91,13 @@ FUNCTION commsEventHandler {
 
 	//	After everything is done, remove the message from message queue
 	CORE:MESSAGES:POP.
-	//	Reset event flag
-	SET commsEventFlag TO FALSE.
-	//	Re-create the comms event trigger
-	setComms().
 }
 
 //	Make sure message is in the correct format
 FUNCTION verifyMessageFormat {
 	PARAMETER type.
 	PARAMETER data.
-	
+
 	//	Response is a lexicon by default. If we encounter any error, it will change type to a string,
 	//	and this is how we know that the format verification failed.
 	SET responseData TO LEXICON().

--- a/kOS/pegas_events.ks
+++ b/kOS/pegas_events.ks
@@ -238,7 +238,7 @@ FUNCTION internalEvent_staging {
 			}
 			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
 		} ELSE {
-			pushUIMessage( "Unknown event type (" + event["ullage"] + ")!", 5, PRIORITY_HIGH ).
+			pushUIMessage( "Unknown ullage mode (" + event["ullage"] + ")!", 5, PRIORITY_HIGH ).
 		}
 	} ELSE {
 		//	If this event does not need ignition, staging is over at this moment
@@ -248,7 +248,7 @@ FUNCTION internalEvent_staging {
 
 	//	Print messages for regular stages and constant-acceleration mode activation.
 	IF NOT vehicle[upfgStage]["isVirtualStage"] {
-		pushUIMessage(stageName + " - activation").
+		pushUIMessage("Staging sequence commencing...").
 	} ELSE IF vehicle[upfgStage]["mode"] = 2 {
 		pushUIMessage("Constant acceleration mode activated.").
 	}
@@ -289,7 +289,7 @@ FUNCTION userEvent_shutdown {
 		engine:SHUTDOWN().
 	}
 	IF NOT event:HASKEY("message") {
-		event:ADD("message", "Shutting down engine(s) tagged '" + event["engineTag"] + "'.").
+		event:ADD("message", "Shutting down engine(s): '" + event["engineTag"] + "'.").
 	}
 }
 
@@ -299,7 +299,7 @@ FUNCTION userEvent_roll {
 
 	SET steeringRoll TO event["angle"].
 	IF NOT event:HASKEY("message") {
-		event:ADD("message", "Rolling to " + steeringRoll + " degrees").
+		event:ADD("message", "Rolling to " + steeringRoll + " degrees.").
 	}
 }
 
@@ -309,7 +309,7 @@ FUNCTION userEvent_delegate {
 
 	LOCAL fun IS event["function"].
 	IF fun:ISDEAD() {
-		pushUIMessage("DEAD DELEGATE - UNABLE TO CALL", 10, PRIORITY_CRITICAL).
+		pushUIMessage("DEAD DELEGATE - UNABLE TO CALL!", 10, PRIORITY_CRITICAL).
 	} ELSE {
 		fun:CALL().
 	}

--- a/kOS/pegas_events.ks
+++ b/kOS/pegas_events.ks
@@ -1,0 +1,299 @@
+//	Event handling library.
+
+//	Utility to insert an event into the sequence by time order
+FUNCTION insertEvent {
+	//	Expects a global variable "sequence" as list of lexicons.
+	DECLARE PARAMETER event.		//	Expects a lexicon
+
+	LOCAL eventTime IS event["time"].
+	//	Go over the list to find the index of insertion...
+	LOCAL index IS 0.
+	FOR this IN sequence {
+		IF eventTime < this["time"] {
+			//	This will cause insertion of the new item AFTER any other item with exact same timing
+			BREAK.
+		}
+		SET index TO index + 1.
+	}
+	//	...and insert there.
+	sequence:INSERT(index, event).
+}
+
+//	Create sequence entries for staging events
+FUNCTION spawnStagingEvents {
+	//	For each active stage we have to schedule the preStage event and the staging event - except the FIRST ONE which is already
+	//	preStaged by now and we just need to stage it (which will possibly be a no-op if it's a sustainer). We'll iterate over the
+	//	vehicle, computing (cumulatively) burnout times for each stage and spawning events. We know exactly when everything starts:
+	//	`controls["upfgActivation"]`.
+	//	Expects global variables:
+	//	"controls" as lexicon
+	//	"vehicle" as list
+	//	"stagingKillRotTime" as scalar
+	LOCAL stageActivationTime IS controls["upfgActivation"].
+	LOCAL vehicleIterator IS vehicle:ITERATOR.
+	//	The first active stage is already pre-staged so we only need to create the staging event
+	vehicleIterator:NEXT.
+	LOCAL stagingEvent IS LEXICON(
+		"time", stageActivationTime,
+		"type", "_upfgstage",
+		"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
+		"message", "active guidance on" // todo: clarify all messages related to staging and virtual stages
+	).
+	//	Insert it into sequence
+	insertEvent(stagingEvent).
+	//	Compute burnout time for this stage and add to sAT (this involves activation time and burn time)
+	SET stageActivationTime TO stageActivationTime + getStageDelays(vehicleIterator:VALUE) + vehicleIterator:VALUE["maxT"].
+	//	Loop over remaining stages
+	UNTIL NOT vehicleIterator:NEXT {
+		//	Construct & insert pre-stage event
+		LOCAL stagingTransitionTime IS stagingKillRotTime.
+		IF vehicleIterator:VALUE["isVirtualStage"] { SET stagingTransitionTime TO 2. }
+		LOCAL stagingEvent IS LEXICON(
+			"time", stageActivationTime - stagingTransitionTime,
+			"type", "_prestage",
+			"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
+			"message", vehicleIterator:VALUE["name"]
+		).
+		insertEvent(stagingEvent).
+		//	Construct & insert staging event
+		LOCAL stagingEvent IS LEXICON(
+			"time", stageActivationTime,
+			"type", "_upfgstage",
+			"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
+			"message", vehicleIterator:VALUE["name"]
+		).
+		insertEvent(stagingEvent).
+		//	Compute next stage time
+		SET stageActivationTime TO stageActivationTime + getStageDelays(vehicleIterator:VALUE) + vehicleIterator:VALUE["maxT"].
+	}
+}
+
+//	Executes a scheduled sequence/staging event.
+FUNCTION eventHandler {
+	//	Clock-based mechanics that is uniform across calls (first call is just like any other) and fully deterministic.
+	//	First we check if we have any events left to execute, and if so - what time should we execute it at.
+	//	Finally, we check whether it's time to handle it, and if so - dispatch to specific handling subroutine.
+	//	Expects global variables:
+	//	"sequence" as list
+	//	"vehicle" as list
+	//	"liftoffTime" as timespan
+	//	"stagingInProgress" as bool
+	//	"steeringRoll" as scalar
+	//	"throttleSetting" as scalar
+	//	"throttleDisplay" as scalar
+	//	"upfgStage" as scalar
+	//	"eventPointer" as scalar
+	LOCAL nextEventPointer IS eventPointer + 1.
+	IF nextEventPointer >= sequence:LENGTH {
+		RETURN.	//	No more events in the sequence
+	}
+	LOCAL nextEventTime IS liftoffTime:SECONDS + sequence[nextEventPointer]["time"].
+	IF TIME:SECONDS < nextEventTime {
+		RETURN.	//	Not yet time to handle this one.
+	}
+
+	//	If we got this far, means it's time to handle the event
+	LOCAL event IS sequence[nextEventPointer].
+	LOCAL eType IS event["type"].
+	IF      eType = "print" OR eType = "p" { }
+	ELSE IF eType = "stage" OR eType = "s" {
+		STAGE.
+	}
+	ELSE IF eType = "jettison" OR eType = "j" {
+		STAGE.
+	}
+	ELSE IF eType = "throttle" OR eType = "t" {
+		userEvent_throttle(event).
+	}
+	ELSE IF eType = "shutdown" OR eType = "u" {
+		userEvent_shutdown(event).
+	}
+	ELSE IF eType = "roll" OR eType = "r" {
+		userEvent_roll(event).
+	}
+	ELSE IF eType = "delegate" OR eType = "d" {
+		userEvent_delegate(event).
+	}
+	ELSE IF eType = "_prestage" {
+		internalEvent_preStage().
+	}
+	ELSE IF eType = "_upfgstage" {
+		internalEvent_staging().
+	}
+	ELSE {
+		pushUIMessage( "Unknown event type (" + eType + ", message='" + event["message"] + "')!", 5, PRIORITY_HIGH ).
+	}
+
+	//	Print event message, if requested
+	IF event:HASKEY("message") {
+		pushUIMessage( event["message"] ).
+	}
+
+	//	Mark the event as handled by incrementing the pointer
+	SET eventPointer TO eventPointer + 1.
+
+	//	Run again to handle "overlapping" events
+	//	This is not infinite recursion, because if there is no overlapping event to handle, the next call will RETURN early.
+	eventHandler().
+}
+
+//	EVENT HANDLING SUBROUTINES
+
+//	Handle the pre-staging event
+FUNCTION internalEvent_preStage {
+	//	Switch to staging mode, increment the stage counter and force UPFG reconvergence.
+	//	Rationale is not changed: we want to maintain constant attitude while the current stage is still burning,
+	//	but at the same time start converging guidance for the subsequent stage.
+	SET stagingInProgress TO TRUE.
+	SET upfgStage TO upfgStage + 1.
+	SET upfgConverged TO FALSE.
+	usc_convergeFlags:CLEAR().
+}
+
+//	Handle the physical staging event
+FUNCTION internalEvent_staging {
+	//	Staging event is a potentially complex procedure consisting of several steps.
+	//	Instead of breaking it down into multiple individual events (understood as sequence items), we use the
+	//	trigger mechanism to handle them. When staging occurs, several triggers are scheduled to handle every
+	//	single step of the procedure in a timely manner.
+	LOCAL currentTime IS TIME:SECONDS.
+	LOCAL event IS vehicle[upfgStage]["staging"].
+	LOCAL stageName IS vehicle[upfgStage]["name"].
+	LOCAL eventDelay IS 0.	//	Keep track of time between subsequent events.
+	IF upfgStage > 0 AND vehicle[upfgStage-1]["shutdownRequired"] {
+		SET throttleSetting TO 0.
+		SET throttleDisplay TO 0.
+	}
+	IF event["jettison"] {
+		GLOBAL stageJettisonTime IS currentTime + event["waitBeforeJettison"].
+		WHEN TIME:SECONDS >= stageJettisonTime THEN {
+			STAGE.
+			pushUIMessage(stageName + " - separation").
+		}
+		SET eventDelay TO eventDelay + event["waitBeforeJettison"].
+	}
+	IF event["ignition"] {
+		IF event["ullage"] = "rcs" {
+			GLOBAL ullageIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
+			WHEN TIME:SECONDS >= ullageIgnitionTime THEN {
+				RCS ON.
+				SET SHIP:CONTROL:FORE TO 1.0.
+				pushUIMessage(stageName + " - RCS ullage on").
+			}
+			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
+			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["ullageBurnDuration"].
+			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
+				STAGE.
+				updateStageEndTime().
+				SET stagingInProgress TO FALSE.
+				pushUIMessage(stageName + " - ignition").
+			}
+			SET eventDelay TO eventDelay + event["ullageBurnDuration"].
+			GLOBAL ullageShutdownTime IS currentTime + eventDelay + event["postUllageBurn"].
+			WHEN TIME:SECONDS >= ullageShutdownTime THEN {
+				SET SHIP:CONTROL:FORE TO 0.0.
+				RCS OFF.
+				pushUIMessage(stageName + " - RCS ullage off").
+			}
+		} ELSE IF event["ullage"] = "srb" {
+			GLOBAL ullageIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
+			WHEN TIME:SECONDS >= ullageIgnitionTime THEN {
+				STAGE.
+				pushUIMessage(stageName + " - SRB ullage ignited").
+			}
+			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
+			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["ullageBurnDuration"].
+			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
+				STAGE.
+				updateStageEndTime().
+				SET stagingInProgress TO FALSE.
+				pushUIMessage(stageName + " - ignition").
+			}
+			SET eventDelay TO eventDelay + event["ullageBurnDuration"].
+		} ELSE IF event["ullage"] = "none" {
+			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
+			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
+				STAGE.
+				updateStageEndTime().
+				SET stagingInProgress TO FALSE.
+				pushUIMessage(stageName + " - ignition").
+			}
+			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
+		} ELSE {
+			pushUIMessage( "Unknown event type (" + event["ullage"] + ")!", 5, PRIORITY_HIGH ).
+		}
+	} ELSE {
+		//	If this event does not need ignition, staging is over at this moment
+		SET stagingInProgress TO FALSE.
+		//	If this was the sustainer stage activation event, we also have to:
+		updateStageEndTime().
+	}
+
+	//	Print messages for regular stages and constant-acceleration mode activation.
+	IF NOT vehicle[upfgStage]["isVirtualStage"] {
+		pushUIMessage(stageName + " - activation").
+	} ELSE IF vehicle[upfgStage]["mode"] = 2 {
+		pushUIMessage("Constant acceleration mode activated.").
+	}
+}
+
+//	Handle the throttle event
+FUNCTION userEvent_throttle {
+	//	Throttling is only allowed during the passive guidance phase, as it would ruin burn time predictions used
+	//	for guidance and stage timing.
+	DECLARE PARAMETER event.	//	Expects a lexicon
+
+	IF upfgStage < 0 {
+		IF NOT event:HASKEY("message") {
+			IF event["throttle"] < throttleSetting {
+				event:ADD("message", "Throttling down to " + 100*event["throttle"] + "%").
+			} ELSE {
+				event:ADD("message", "Throttling up to " + 100*event["throttle"] + "%").
+			}
+		}
+		SET throttleSetting TO event["throttle"].
+		SET throttleDisplay TO throttleSetting.
+	} ELSE {
+		pushUIMessage( "Throttle ignored in active guidance!", 5, PRIORITY_HIGH ).
+	}
+}
+
+//	Handle the engine shutdown event
+FUNCTION userEvent_shutdown {
+	DECLARE PARAMETER event.	//	Expects a lexicon
+
+	//	Find the tagged engines
+	LOCAL taggedEngines IS SHIP:PARTSTAGGED(event["engineTag"]).
+	IF taggedEngines:LENGTH = 0 {
+		pushUIMessage("NO ENGINES TAGGED '" + event["engineTag"] + "' FOUND!", 10, PRIORITY_CRITICAL).
+	}
+	//	Shut them down
+	FOR engine IN taggedEngines {
+		engine:SHUTDOWN().
+	}
+	IF NOT event:HASKEY("message") {
+		event:ADD("message", "Shutting down engine(s) tagged '" + event["engineTag"] + "'.").
+	}
+}
+
+//	Handle the roll event
+FUNCTION userEvent_roll {
+	DECLARE PARAMETER event.	//	Expects a lexicon
+
+	SET steeringRoll TO event["angle"].
+	IF NOT event:HASKEY("message") {
+		event:ADD("message", "Rolling to " + steeringRoll + " degrees").
+	}
+}
+
+//	Handle the delegate event
+FUNCTION userEvent_delegate {
+	DECLARE PARAMETER event.	//	Expects a lexicon
+
+	LOCAL fun IS event["function"].
+	IF fun:ISDEAD() {
+		pushUIMessage("DEAD DELEGATE - UNABLE TO CALL", 10, PRIORITY_CRITICAL).
+	} ELSE {
+		fun:CALL().
+	}
+}

--- a/kOS/pegas_events.ks
+++ b/kOS/pegas_events.ks
@@ -83,8 +83,7 @@ FUNCTION spawnStagingEvents {
 	LOCAL stagingEvent IS LEXICON(
 		"time", stageActivationTime,
 		"type", "_activeon",
-		"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
-		"message", "active guidance on" // todo: clarify all messages related to staging and virtual stages
+		"isVirtual", vehicleIterator:VALUE["isVirtualStage"]
 	).
 	insertEvent(stagingEvent).
 	//	Compute burnout time for this stage and add to sAT (this involves activation time and burn time)
@@ -190,6 +189,7 @@ FUNCTION eventHandler {
 //	Handle transition to active guidance mode
 FUNCTION internalEvent_activeModeOn {
 	SET activeGuidanceMode TO TRUE.
+	pushUIMessage("UPFG activated!").
 }
 
 //	Handle the pre-staging event

--- a/kOS/pegas_events.ks
+++ b/kOS/pegas_events.ks
@@ -19,6 +19,45 @@ FUNCTION insertEvent {
 	sequence:INSERT(index, event).
 }
 
+//	Create countdown print events
+FUNCTION spawnCountdownEvents {
+	//	Generates print events for a standard countdown sequence.
+	//	Expects global variables:
+	//	"liftoffTime" as scalar
+	//	"sequence" as list
+
+	FUNCTION makeEvent {
+		DECLARE PARAMETER timeAfterLiftoff.	//	Expects a scalar
+		DECLARE PARAMETER message.			//	Expects a string
+
+		RETURN LEXICON(
+			"time", timeAfterLiftoff,
+			"type", "print",
+			"message", message,
+			"isVirtual", TRUE
+		).
+	}
+
+	LOCAL timeToLaunch IS liftoffTime:SECONDS - TIME:SECONDS.
+	IF timeToLaunch > 18000 {insertEvent(makeEvent(-18000, "5 hours to launch")).}
+	IF timeToLaunch > 3600  {insertEvent(makeEvent(-3600, "1 hour to launch")).}
+	IF timeToLaunch > 1800  {insertEvent(makeEvent(-1800, "30 minutes to launch")).}
+	IF timeToLaunch > 600   {insertEvent(makeEvent(-600, "10 minutes to launch")).}
+	IF timeToLaunch > 300   {insertEvent(makeEvent(-300, "5 minutes to launch")).}
+	IF timeToLaunch > 60    {insertEvent(makeEvent(-60, "1 minute to launch")).}
+	IF timeToLaunch > 30	{insertEvent(makeEvent(-30, "30 seconds to launch")).}
+	insertEvent(makeEvent(-10, "10 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-9, "9 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-8, "8 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-7, "7 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-6, "6 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-5, "5 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-4, "4 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-3, "3 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-2, "2 SECONDS TO LAUNCH")).
+	insertEvent(makeEvent(-1, "1 SECONDS TO LAUNCH")).
+}
+
 //	Create sequence entries for staging events
 FUNCTION spawnStagingEvents {
 	//	For each active stage we have to schedule the preStage event and the staging event - except the FIRST ONE which is already

--- a/kOS/pegas_misc.ks
+++ b/kOS/pegas_misc.ks
@@ -110,7 +110,7 @@ FUNCTION timePrint {
 		SET deltaT TO currentTime - liftoffTime.
 	} ELSE {
 		SET sign TO "-".
-		SET deltaT TO liftoffTime - currentTime.
+		SET deltaT TO liftoffTime - currentTime + 1.
 	}
 
 	textPrint(sign, 6, 3, 4, "L").

--- a/kOS/pegas_misc.ks
+++ b/kOS/pegas_misc.ks
@@ -164,8 +164,10 @@ FUNCTION refreshUI {
 		SET stageName TO vehicle[upfgStage]["name"].
 		SET stageType TO vehicle[upfgStage]["virtualStageType"].
 		SET currentVelocity TO SHIP:VELOCITY:ORBIT:MAG.
-		//	Time until the stage burns out (and, potentially, the next one's ignition sequence starts)
-		SET stageTgo TO nextStageTime - currentTime:SECONDS.
+		//	Time until the stage burns out (accurate)
+		LOCAL massFlow IS getThrust(vehicle[upfgStage]["engines"])[1].
+		LOCAL fuelMass IS SHIP:MASS*1000 - vehicle[upfgStage]["massDry"].
+		SET stageTgo TO fuelMass / massFlow. // this is wrong for some reason
 		//	Print convergence flag
 		IF stagingInProgress {
 			SET stageName TO "".

--- a/kOS/pegas_util.ks
+++ b/kOS/pegas_util.ks
@@ -132,7 +132,7 @@ FUNCTION missionSetup {
 		LOCAL currentNode IS nodeVector(mission["inclination"], mission["direction"]).
 		LOCAL currentLan IS VANG(currentNode, SOLARPRIMEVECTOR).
 		IF VDOT(V(0,1,0), VCRS(currentNode, SOLARPRIMEVECTOR)) < 0 { SET currentLan TO 360 - currentLan. }
-		SET mission["LAN"] TO currentLan + (controls["launchTimeAdvance"] + 30)/SHIP:ORBIT:BODY:ROTATIONPERIOD*360.
+		SET mission["LAN"] TO currentLan + (controls["launchTimeAdvance"] + 32)/SHIP:ORBIT:BODY:ROTATIONPERIOD*360.
 	}
 }
 

--- a/kOS/pegas_util.ks
+++ b/kOS/pegas_util.ks
@@ -379,7 +379,7 @@ FUNCTION targetNormal {
 	RETURN -vecYZ(normalVec).
 }
 
-//	EVENT HANDLING FUNCTIONS
+//	VEHICLE DATA PREPARATION FOR UPFG
 
 //	Setup vehicle: transform user input to UPFG-compatible struct
 FUNCTION setVehicle {
@@ -660,189 +660,17 @@ FUNCTION initializeVehicleForUPFG {
 	SET upfgStage TO 0.	//	The vehicle is ready so we can start the actual preconvergence for the first active stage
 }
 
-//	Executes a user (sequence) event.
-FUNCTION userEventHandler {
-	//	Clock-based mechanics that is uniform across calls (first call is just like any other) and fully in control
-	//	First we check if we have any events left to execute, and if so - what time should we execute it at.
-	//	Finally, we check whether it's time to handle it.
-	//	Expects global variables:
-	//	"sequence" as list
-	//	"vehicle" as list
-	//	"liftoffTime" as timespan
-	//	"steeringRoll" as scalar
-	//	"userEventPointer" as scalar
-	//	"upfgStage" as scalar
-	LOCAL nextEventPointer IS userEventPointer + 1.
-	IF nextEventPointer >= sequence:LENGTH {
-		RETURN.	//	No more events in the sequence
-	}
-	LOCAL nextEventTime IS liftoffTime:SECONDS + sequence[nextEventPointer]["time"].
-	IF TIME:SECONDS < nextEventTime {
-		RETURN.	//	Not yet time to handle this one.
-	}
-
-	//	If we got this far, means it's time to handle the event
-	LOCAL event IS sequence[nextEventPointer].
-	LOCAL eType IS event["type"].
-	IF      eType = "print" OR eType = "p" { }
-	ELSE IF eType = "stage" OR eType = "s" { STAGE. }
-	ELSE IF eType = "jettison" OR eType = "j" {
-		//	We used to handle the reduction of vehicle mass here, but it has since been moved to initializeVehicleForUPFG a few lines up.
-		STAGE.
-	}
-	ELSE IF eType = "throttle" OR eType = "t" {
-		//	Throttling is only allowed during the passive guidance phase, as it would ruin burn time predictions used
-		//	for guidance and stage timing.
-		IF upfgStage < 0 {
-			IF NOT event:HASKEY("message") {
-				IF event["throttle"] < throttleSetting {
-					event:ADD("message", "Throttling down to " + 100*event["throttle"] + "%").
-				} ELSE {
-					event:ADD("message", "Throttling up to " + 100*event["throttle"] + "%").
-				}
-			}
-			SET throttleSetting TO event["throttle"].
-			SET throttleDisplay TO throttleSetting.
-		} ELSE {
-			pushUIMessage( "Throttle ignored in active guidance!", 5, PRIORITY_HIGH ).
-		}
-	}
-	ELSE IF eType = "shutdown" OR eType = "u" {
-		//	Find the tagged engines
-		LOCAL taggedEngines IS SHIP:PARTSTAGGED(event["engineTag"]).
-		IF taggedEngines:LENGTH = 0 {
-			pushUIMessage("NO ENGINES TAGGED '" + event["engineTag"] + "' FOUND!", 10, PRIORITY_CRITICAL).
-		}
-		//	Shut them down
-		FOR engine IN taggedEngines {
-			engine:SHUTDOWN().
-		}
-		IF NOT event:HASKEY("message") {
-			event:ADD("message", "Shutting down engine(s) tagged '" + event["engineTag"] + "'.").
-		}
-	}
-	ELSE IF eType = "roll" OR eType = "r" {
-		SET steeringRoll TO event["angle"].
-		IF NOT event:HASKEY("message") {
-			event:ADD("message", "Rolling to " + steeringRoll + " degrees").
-		}
-	}
-	ELSE IF eType = "delegate" OR eType = "d" {
-		event["function"]:CALL().
-	}
-	ELSE IF eType = "_prestage" {
-		internalEvent_preStage().
-	}
-	ELSE IF eType = "_upfgstage" {
-		internalEvent_staging().
-	}
-	ELSE { pushUIMessage( "Unknown event type (" + eType + ", message='" + event["message"] + "')!", 5, PRIORITY_HIGH ). }
-
-	//	Print event message, if requested
-	IF event:HASKEY("message") {
-		pushUIMessage( event["message"] ).
-	}
-
-	//	Mark the event as handled by incrementing the pointer
-	SET userEventPointer TO userEventPointer + 1.
-
-	//	Run again to handle "overlapping" events
-	//	This is not infinite recursion, because if there is no overlapping event to handle, the next call will RETURN early.
-	userEventHandler().
-}
-
-FUNCTION internalEvent_preStage {
-	SET stagingInProgress TO TRUE.
-	SET upfgStage TO upfgStage + 1.
-	SET upfgConverged TO FALSE.
-	usc_convergeFlags:CLEAR().
-}
-
-FUNCTION internalEvent_staging {
-	LOCAL currentTime IS TIME:SECONDS.
-	LOCAL event IS vehicle[upfgStage]["staging"].
-	LOCAL stageName IS vehicle[upfgStage]["name"].
-	LOCAL eventDelay IS 0.	//	Keep track of time between subsequent events.
-	IF upfgStage > 0 AND vehicle[upfgStage-1]["shutdownRequired"] {
-		SET throttleSetting TO 0.
-		SET throttleDisplay TO 0.
-	}
-	IF event["jettison"] {
-		GLOBAL stageJettisonTime IS currentTime + event["waitBeforeJettison"].
-		WHEN TIME:SECONDS >= stageJettisonTime THEN {
-			STAGE.
-			pushUIMessage(stageName + " - separation").
-		}
-		SET eventDelay TO eventDelay + event["waitBeforeJettison"].
-	}
-	IF event["ignition"] {
-		IF event["ullage"] = "rcs" {
-			GLOBAL ullageIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
-			WHEN TIME:SECONDS >= ullageIgnitionTime THEN {
-				RCS ON.
-				SET SHIP:CONTROL:FORE TO 1.0.
-				pushUIMessage(stageName + " - RCS ullage on").
-			}
-			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
-			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["ullageBurnDuration"].
-			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
-				STAGE.
-				updateStageEndTime().
-				SET stagingInProgress TO FALSE.
-				pushUIMessage(stageName + " - ignition").
-			}
-			SET eventDelay TO eventDelay + event["ullageBurnDuration"].
-			GLOBAL ullageShutdownTime IS currentTime + eventDelay + event["postUllageBurn"].
-			WHEN TIME:SECONDS >= ullageShutdownTime THEN {
-				SET SHIP:CONTROL:FORE TO 0.0.
-				RCS OFF.
-				pushUIMessage(stageName + " - RCS ullage off").
-			}
-		} ELSE IF event["ullage"] = "srb" {
-			GLOBAL ullageIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
-			WHEN TIME:SECONDS >= ullageIgnitionTime THEN {
-				STAGE.
-				pushUIMessage(stageName + " - SRB ullage ignited").
-			}
-			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
-			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["ullageBurnDuration"].
-			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
-				STAGE.
-				updateStageEndTime().
-				SET stagingInProgress TO FALSE.
-				pushUIMessage(stageName + " - ignition").
-			}
-			SET eventDelay TO eventDelay + event["ullageBurnDuration"].
-		} ELSE IF event["ullage"] = "none" {
-			GLOBAL engineIgnitionTime IS currentTime + eventDelay + event["waitBeforeIgnition"].
-			WHEN TIME:SECONDS >= engineIgnitionTime THEN {
-				STAGE.
-				updateStageEndTime().
-				SET stagingInProgress TO FALSE.
-				pushUIMessage(stageName + " - ignition").
-			}
-			SET eventDelay TO eventDelay + event["waitBeforeIgnition"].
-		} ELSE {
-			pushUIMessage( "Unknown event type (" + event["ullage"] + ")!", 5, PRIORITY_HIGH ).
-		}
-	} ELSE {
-		//	If this event does not need ignition, staging is over at this moment
-		SET stagingInProgress TO FALSE.
-		//	If this was the sustainer stage activation event, we also have to:
-		updateStageEndTime().
-	}
-
-	//	Print messages for regular stages and constant-acceleration mode activation.
-	IF NOT vehicle[upfgStage]["isVirtualStage"] {
-		pushUIMessage(stageName + " - activation").
-	} ELSE IF vehicle[upfgStage]["mode"] = 2 {
-		pushUIMessage("Constant acceleration mode activated.").
-	}
-}
-
+//	Utility to keep track of actively guided stage burnouts
 FUNCTION updateStageEndTime {
+	//	The staging event calls this when a stage is activated, to calculate when the stage will run out of fuel.
+	//	This is useful, because we can use this value to estimate a true Tgo for that stage. Doubly so, as we can
+	//	easily calculate the total burn time for the entire physical stage. The value might be off by 1-2 seconds
+	//	because of the engine spool-up time (#wontfix).
+	//	Expects global variables:
+	//	"vehicle" as list
+	//	"upfgStage" as scalar
 	LOCAL stageBurnTime IS 0.
-	//	Calculate the complete burn time of the entire physical stage, including the subsequent virtuals
+	//	Calculate the complete burn time including the subsequent virtual stages.
 	LOCAL i IS 0.
 	FOR stg in vehicle {
 		//	Forward to the current stage
@@ -891,11 +719,20 @@ FUNCTION upfgSteeringControl {
 		pushUIMessage( "UPFG reset", 5, PRIORITY_CRITICAL ).
 	}
 
-	//	Expects global variables "upfgConverged" and "stagingInProgress" as bool, "steeringVector" as vector,
-	//	"upfgConvergenceCriterion", "upfgGoodSolutionCriterion", "steeringRoll" and "liftoffTime" as scalars,
-	//	"vehicle" as list, and "controls" as lexicon.
-	//	Owns global variables "usc_lastGoodVector" as vector, "usc_convergeFlags" as list, and
-	//	"usc_lastIterationTime" as scalar.
+	//	Expects global variables:
+	//	"upfgConverged" as bool
+	//	"stagingInProgress" as bool
+	//	"steeringVector" as vector
+	//	"upfgConvergenceCriterion" as scalar
+	//	"upfgGoodSolutionCriterion" as scalar
+	//	"steeringRoll" as scalar
+	//	"liftoffTime" as timespan
+	//	"vehicle" as list
+	//	"controls" as lexicon
+	//	Owns global variables:
+	//	"usc_lastGoodVector" as vector
+	//	"usc_convergeFlags" as list
+	//	"usc_lastIterationTime" as scalar
 	DECLARE PARAMETER vehicle.		//	Expects a list of lexicon
 	DECLARE PARAMETER upfgStage.	//	Expects a scalar
 	DECLARE PARAMETER upfgTarget.	//	Expects a lexicon
@@ -993,66 +830,4 @@ FUNCTION throttleControl {
 		SET throttleDisplay TO desiredThrottle.
 	}
 	ELSE { pushUIMessage( "throttleControl stage error (stage=" + upfgStage + "(" + whichStage + "), mode=" + vehicle[whichStage]["mode"] + ")!", 5, PRIORITY_CRITICAL ). }.
-}
-
-//	Create sequence entries for staging events
-FUNCTION spawnStagingEvents {
-	//	For each active stage we have to schedule the preStage event and the staging event - except the FIRST ONE which is already
-	//	preStaged by now and we just need to stage it (which will possibly be a no-op if it's a sustainer). We'll iterate over the
-	//	vehicle, computing (cumulatively) burnout times for each stage and spawning events. We know exactly when everything starts:
-	//	`controls["upfgActivation"]`.
-	LOCAL stageActivationTime IS controls["upfgActivation"].
-	LOCAL vehicleIterator IS vehicle:ITERATOR.
-	//	The first active stage is already pre-staged so we only need to create the staging event
-	vehicleIterator:NEXT.
-	LOCAL stagingEvent IS LEXICON(
-		"time", stageActivationTime,
-		"type", "_upfgstage",
-		"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
-		"message", "active guidance on" // todo: clarify all messages related to staging and virtual stages
-	).
-	//	Insert it into sequence
-	insertEvent(stagingEvent).
-	//	Compute burnout time for this stage and add to sAT (this involves activation time and burn time)
-	SET stageActivationTime TO stageActivationTime + getStageDelays(vehicleIterator:VALUE) + vehicleIterator:VALUE["maxT"].
-	//	Loop over remaining stages
-	UNTIL NOT vehicleIterator:NEXT {
-		//	Construct & insert pre-stage event
-		LOCAL stagingTransitionTime IS stagingKillRotTime.
-		IF vehicleIterator:VALUE["isVirtualStage"] { SET stagingTransitionTime TO 2. }
-		LOCAL stagingEvent IS LEXICON(
-			"time", stageActivationTime - stagingTransitionTime,
-			"type", "_prestage",
-			"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
-			"message", vehicleIterator:VALUE["name"]
-		).
-		insertEvent(stagingEvent).
-		//	Construct & insert staging event
-		LOCAL stagingEvent IS LEXICON(
-			"time", stageActivationTime,
-			"type", "_upfgstage",
-			"isVirtual", vehicleIterator:VALUE["isVirtualStage"],
-			"message", vehicleIterator:VALUE["name"]
-		).
-		insertEvent(stagingEvent).
-		//	Compute next stage time
-		SET stageActivationTime TO stageActivationTime + getStageDelays(vehicleIterator:VALUE) + vehicleIterator:VALUE["maxT"].
-	}
-}
-
-//	Insert an event into the sequence by time order
-FUNCTION insertEvent {
-	DECLARE PARAMETER event.
-	LOCAL eventTime IS event["time"].
-	//	Go over the list to find the index of insertion...
-	LOCAL index IS 0.
-	FOR this IN sequence {
-		IF eventTime < this["time"] {
-			//	This will cause insertion of the new item AFTER any other item with exact same timing
-			BREAK.
-		}
-		SET index TO index + 1.
-	}
-	//	...and insert there.
-	sequence:INSERT(index, event).
 }


### PR DESCRIPTION
I decided to go with #39 and this is what I came up with.

Things done here:
- [x] system events removed
- [x] user events reimplemented to use explicit timing instead of `WHEN` and a flag
- [x] stage events merged with user events (from now on we're only talking about "events")
- [x] events refactored as a separate module (also delegate event now has an `:ISDEAD()` check)
- [x] stage time-to-go calculation fixed
- [x] comm events handler reimplemented in the similar fashion
- [x] clarifying the staging/UPFG mess
- [x] clarifying the UI messages
- [x] bringing _back_ system events (countdown!)
- [x] docs cleanup

What this gives us is that now the entire sequence - this time meaning _both_ the user defined events in `sequence` and PEGAS-scheduled staging events from `vehicle`, so the complete "launch sequence" if you will - is pretty much exactly deterministic and explicit. The system becomes much cleaner (one does no longer have to track `userEventFlag`, which is not triggered in any mainline code but by a mysterious and untraceable `WHEN`) and less prone to errors (what about two events scheduled to happen in rapid succession? this is potentially problematic in the comms subsystem). But the main reason is that now we have one place to look for **all** things that will happen in the future. And this means #37 is now possible.

I'll be updating this with future developments and if all goes well, merge it later this week.

PS: @Patrykz94 if you're still around here somewhere, would you mind taking this for a spin and checking if your booster recovery missions still work? I've never used comms myself, and while I _believe_ I've done everything right, it'd put my mind at ease if you confirmed that it indeed still works as intended.

Closes #39