### PR TITLE
Programmable passive guidance mode - adapted from #35

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -18,14 +18,39 @@ List of possible keys:
 Key                | Units | Opt/req  | Meaning
 ---                | ---   | ---      | ---
 launchTimeAdvance  | s     | required | Launch time will be scheduled that many seconds before the launch site rotates directly under the target orbit
-verticalAscentTime | s     | required | After liftoff, vehicle will fly straight up for that many seconds before pitching over
-pitchOverAngle     | deg   | required | Vehicle will pitch over by that many degrees away from vertical
+verticalAscentTime | s     | optional\* | After liftoff, vehicle will fly straight up for that many seconds before pitching over
+pitchOverAngle     | deg   | optional\* | Vehicle will pitch over by that many degrees away from vertical
+pitchStartAlt      | m     | optional\* | After liftoff, vehicle will fly straight up until this altitude
+pitchControl       | `list` | optional\* | A list of pitch angle & altitude pairs
 upfgActivation     | s     | required | The active guidance phase will be activated that many seconds after liftoff
-launchAzimuth      | deg   | optional | Overrides automatic launch azimuth calculation, giving some basic optimization capability\*
+launchAzimuth      | deg   | optional | Overrides automatic launch azimuth calculation, giving some basic optimization capability\*\*
 initialRoll        | deg   | optional | Angle to which the vehicle will roll during the initial pitchover maneuver (default is 0)
 disableThrustWatchdog | `boolean` | optional | Set to `TRUE` in order to disable loss-of-thrust checking on this vehicle, ignore this key otherwise.
 
-\* - see notes to [`mission`](#mission) struct.
+\* - of the four fields, only **two** have to be provided:
+first solution is to provide `verticalAscentTime` and `pitchOverAngle`;
+the vehicle will fly straight up until `verticalAscentTime` seconds, then pitch `pitchOverAngle` degrees,
+following that angle until the vehicle starts tracking the prograde vector.
+The second solution is to use `pitchStartAlt` with `pitchControl`
+in order to precisely control your initial ascent phase,
+as described in the [`pitchControl`](#pitchcontrol) section below.
+
+\*\* - see notes to [`mission`](#mission) struct.
+
+#### pitchControl
+
+`pitchControl` allows you to completely control your atmospheric ascent phase
+by setting the pitch angle as a linear function of the ASL altitude.
+Linear regression is made from 90 degrees (which corresponds to straight up) to a specified final angle,
+starting at altitude given in `pitchStartAlt`.
+PEGAS calculates the linear regression for you and locks pitch to (a * altitude + b).
+
+`pitchControl` 's `LEXICON` follow these rules:
+
+Key         | Units | Opt/req   | Meaning
+---         | ---   | ---       | ---
+`endAlt`    | m     | required  | The altitude in which the `endPitch` angle will be reached
+`endPitch`  | deg   | required  | The desired pitch angle to reach at altitude `endAlt`
 
 ### Vehicle
 `GLOBAL vehicle IS LIST().`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,37 +20,40 @@ Key                | Units | Opt/req  | Meaning
 launchTimeAdvance  | s     | required | Launch time will be scheduled that many seconds before the launch site rotates directly under the target orbit
 verticalAscentTime | s     | optional\* | After liftoff, vehicle will fly straight up for that many seconds before pitching over
 pitchOverAngle     | deg   | optional\* | Vehicle will pitch over by that many degrees away from vertical
-pitchStartAlt      | m     | optional\* | After liftoff, vehicle will fly straight up until this altitude
-pitchControl       | `list` | optional\* | A list of pitch angle & altitude pairs
+pitchProgram       | `lexicon` | optional\* | Vehicle will follow a pitch program given by pitch angle & altitude pairs
 upfgActivation     | s     | required | The active guidance phase will be activated that many seconds after liftoff
 launchAzimuth      | deg   | optional | Overrides automatic launch azimuth calculation, giving some basic optimization capability\*\*
 initialRoll        | deg   | optional | Angle to which the vehicle will roll during the initial pitchover maneuver (default is 0)
 disableThrustWatchdog | `boolean` | optional | Set to `TRUE` in order to disable loss-of-thrust checking on this vehicle, ignore this key otherwise.
 
-\* - of the four fields, only **two** have to be provided:
-first solution is to provide `verticalAscentTime` and `pitchOverAngle`;
-the vehicle will fly straight up until `verticalAscentTime` seconds, then pitch `pitchOverAngle` degrees,
+\* - of those three fields, you have to provide **EITHER** `verticalAscentTime` and `pitchOverAngle`
+**OR** `pitchProgram`.
+In the first case, vehicle will fly straight up until `verticalAscentTime` seconds,
+then pitch `pitchOverAngle` degrees,
 following that angle until the vehicle starts tracking the prograde vector.
-The second solution is to use `pitchStartAlt` with `pitchControl`
+The alternative is to specify `pitchProgram`
 in order to precisely control your initial ascent phase,
-as described in the [`pitchControl`](#pitchcontrol) section below.
+as described in the [`pitchProgram`](#pitchprogram) section below.
 
 \*\* - see notes to [`mission`](#mission) struct.
 
-#### pitchControl
+#### pitchProgram
 
-`pitchControl` allows you to completely control your atmospheric ascent phase
+`pitchProgram` allows you to completely control your atmospheric ascent phase
 by setting the pitch angle as a linear function of the ASL altitude.
-Linear regression is made from 90 degrees (which corresponds to straight up) to a specified final angle,
-starting at altitude given in `pitchStartAlt`.
-PEGAS calculates the linear regression for you and locks pitch to (a * altitude + b).
+Define your trajectory by declaring a list of keypoint altitudes and a corresponding list of desired pitch angles,
+and PEGAS will calculate a piecewise-linear function between each pair,
+locking pitch to (a * altitude + b).  
+**Note**: for technical reasons, the first entry in the `pitch` list must be 90 (straight up),
+and the first entry in the `altitude` list must be the altitude at which you want to start turning.
+In other words, your vehicle will fly vertically until it reaches altitude given in this first entry.
 
-`pitchControl` 's `LEXICON` follow these rules:
+Exact specification of the `pitchProgram` lexicon:
 
 Key         | Units | Opt/req   | Meaning
 ---         | ---   | ---       | ---
-`endAlt`    | m     | required  | The altitude in which the `endPitch` angle will be reached
-`endPitch`  | deg   | required  | The desired pitch angle to reach at altitude `endAlt`
+`altitude`  | m     | required  | Keypoint altitudes
+`pitch`     | deg   | required  | Desired pitch angle to reach at the corresponding altitude
 
 ### Vehicle
 `GLOBAL vehicle IS LIST().`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -101,6 +101,17 @@ Delta-v losses from sub-optimal steering are not something you need to worry abo
 Tuning might prove particularly difficult if you're getting low ingame FPS during liftoff, or your launch clamps misbehave.
 Unpredictable separation that disrupts your vehicle from flying straight can even make good settings randomly fail - beware.
 
+##### `pitchStartAlt` and `pitchControl`
+For some vessels the above solution (with `verticalAscentTime` and `pitchOverAngle`) does not give enough controllability.
+PEGAS provides another approach to guide your vehicles through the atmospheric climb with more accuracy.
+You simply give an altitude from which the rocket will start the pitch maneuver (from 90 deg, since your rocket always lifts off from vertical position).
+Then you pass several altitude/pitchAngle pairs as `pitchControl` so that PEGAS
+makes a linear regression, calculating pitch as a function of altitude.
+Each altitude/pitchAngle pair will result in one linear segment of the ascent trajectory.
+
+Both solutions require that you know your rocket to define at least one set of values.
+For more information see the [pitchControl](reference.md#pitchcontrol) section of the reference.
+
 ##### upfgActivation
 This is when the atmospheric ascent ends, and active guidance begins.
 You want to be outside the atmosphere when that happens, 40-50 km is good.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -101,22 +101,34 @@ Delta-v losses from sub-optimal steering are not something you need to worry abo
 Tuning might prove particularly difficult if you're getting low ingame FPS during liftoff, or your launch clamps misbehave.
 Unpredictable separation that disrupts your vehicle from flying straight can even make good settings randomly fail - beware.
 
-##### `pitchStartAlt` and `pitchControl`
+##### pitchProgram
 For some vessels the above solution (with `verticalAscentTime` and `pitchOverAngle`) does not give enough controllability.
-PEGAS provides another approach to guide your vehicles through the atmospheric climb with more accuracy.
-You simply give an altitude from which the rocket will start the pitch maneuver (from 90 deg, since your rocket always lifts off from vertical position).
-Then you pass several altitude/pitchAngle pairs as `pitchControl` so that PEGAS
-makes a linear regression, calculating pitch as a function of altitude.
+PEGAS provides another approach to guide your vehicles through the atmospheric climb with more accuracy: `pitchProgram`
+It allows you to define a precise pitch-vs-altitude program by specifying two lists (as keys of the `pitchProgram` lexicon):
+* `altitude` is a list of "keypoint altitudes",
+* `pitch` is a list of desired pitch angles,
+i.e. at any altitude from the `altitude` list,
+pitch angle will be selected from the corresponding element of this list.
+
+PEGAS will perform linear interpolation between the given pairs of values,
+calculating pitch as a function of altitude.
 Each altitude/pitchAngle pair will result in one linear segment of the ascent trajectory.
 
+**Note**: the first `altitude` entry is of special importance.
+Prior to reaching this altitude, the vehicle will fly at 90 degrees pitch (perfectly vertically) -
+_no matter what the corresponding pitch is_ (although it is recommended to set it to 90).
+Only after this altitude has been reached,
+the linear interpolation kicks in and the vehicle starts following your pitch program.
+
 Both solutions require that you know your rocket to define at least one set of values.
-For more information see the [pitchControl](reference.md#pitchcontrol) section of the reference.
+For more information see the [pitchProgram](reference.md#pitchprogram) section of the reference.
+For an example usage see [SoyuzTMA.ks](../kOS/boot/SoyuzTMA.ks) sample.
 
 ##### upfgActivation
 This is when the atmospheric ascent ends, and active guidance begins.
 You want to be outside the atmosphere when that happens, 40-50 km is good.
 From this moment the UPFG is in control over your vehicle, and if you're too low and it decides to pitch up too much, you might experience your vehicle tumbling out of control for a moment, or even rapidly disassembling.
-It's difficult to provide example numbers, as this variable strongly depends on your vehicle - see the [boot files](kOS/boot).
+It's difficult to provide example numbers, as this variable strongly depends on your vehicle - see the [boot files](../kOS/boot).
 
 ##### Rolling
 Roll control in PEGAS is achieved using two mechanisms.

--- a/kOS/boot/SoyuzTMA.ks
+++ b/kOS/boot/SoyuzTMA.ks
@@ -1,0 +1,43 @@
+GLOBAL vehicle IS LIST(
+	LEXICON(
+		//THIRD STAGE WITH RD-0124
+		"name", "R7, RD-0124 Third Stage",
+		"massTotal", 16772,
+		"massFuel", 3105+3800,
+		"engines", LIST(LEXICON("isp", 330, "thrust", 148000)),
+		"staging", LEXICON(
+			"jettison", FALSE,
+			"ignition", FALSE
+		)
+	)
+).
+
+GLOBAL controls IS LEXICON(
+	"launchTimeAdvance", 140,
+	"upfgActivation", 156,
+	"pitchStartAlt", 200,
+	"pitchControl", LIST(LEXICON("endAlt", 20000, "endPitch", 45), LEXICON("endAlt", 65000, "endPitch", 0))
+).
+
+//Set time (in s) between ignition and liftoff here
+SET IgnTime TO 2.
+
+GLOBAL sequence IS LIST(
+	LEXICON("time", -IgnTime, "type", "stage", "message", "Ignition!"),
+	LEXICON("time", 0, "type", "stage", "message", "Liftoff!"),
+	LEXICON("time", 70-IgnTime, "type", "stage", "message", "LES tower Ejected!" ), //"massLost", 2162,
+	LEXICON("time", 77-IgnTime, "type", "stage", "message", "First Stage is ejecting"),
+	LEXICON("time", 78-IgnTime, "type", "stage", "message", "First Stage is ejected" ),
+	LEXICON("time", 100-IgnTime, "type", "stage", "message", "Fairings Ejected"), //"massLost", 3200,
+	LEXICON("time", 153-IgnTime, "type", "stage", "message", "Third Stage Ignition" ),
+	LEXICON("time", 154-IgnTime, "type", "stage", "message", "Second Stage ejection" )
+).
+
+GLOBAL mission IS LEXICON(
+	"apoapsis", 72,
+	"periapsis", 72,
+	"inclination", 51.65
+).
+
+CLEARSCREEN.
+PRINT "Loaded boot file: Soyuz TMA".

--- a/kOS/boot/SoyuzTMA.ks
+++ b/kOS/boot/SoyuzTMA.ks
@@ -15,8 +15,12 @@ GLOBAL vehicle IS LIST(
 GLOBAL controls IS LEXICON(
 	"launchTimeAdvance", 140,
 	"upfgActivation", 156,
-	"pitchStartAlt", 200,
-	"pitchControl", LIST(LEXICON("endAlt", 20000, "endPitch", 45), LEXICON("endAlt", 65000, "endPitch", 0))
+	"pitchProgram", LEXICON(
+		"altitude", LIST(200, 20000, 65000),
+		"pitch", LIST(90, 45, 0)
+	)
+	//	Read: until altitude 200m fly at 90 degrees, then turn so that at 20km pitch is 45 degrees,
+	//	then continue turning so that at 65km pitch is 0 degrees.
 ).
 
 //Set time (in s) between ignition and liftoff here

--- a/kOS/pegas.ks
+++ b/kOS/pegas.ks
@@ -41,6 +41,7 @@ scanAddons().
 
 
 //	PREFLIGHT ACTIVITIES
+checkControls().		//	Check the controls configuration
 //	Click "control from here" on a part that runs the system.
 //	Helpful when your payload is not perfectly rigidly attached, and you're not sure whether it controls the vessel or not.
 CORE:PART:CONTROLFROM().

--- a/kOS/pegas_atmo.ks
+++ b/kOS/pegas_atmo.ks
@@ -1,0 +1,59 @@
+//	Atmospheric ascent library
+
+//	Basic pitch&hold ascent consists of 4 phases, ascentFlag stores the phase index:
+//	0: vertical ascent
+//	1: pitch over by a given angle
+//	2: hold prograde with a given launch azimuth, emit a UI message
+//	3: hold prograde with a given azimuth
+GLOBAL ascentFlag IS 0.
+
+//	Passive guidance within the atmosphere
+FUNCTION atmosphericSteeringControl {
+	//	Handle the entire atmospheric ascent phase, from vertical ascent, through pitching over,
+	//	to holding prograde at a given azimuth. Called regularly by the main loop, updates the
+	//	steeringVector directly, without returning anything.
+	//	Expects global variables:
+	//	"ascentFlag" as integer
+	//	"controls" as lexicon
+	//	"liftoffTime" as timespan
+	//	"mission" as lexicon
+	//	"SETTINGS" as lexicon
+	//	"steeringVector" as vector
+
+	DECLARE PARAMETER steeringRoll.	//	Expects a scalar
+
+	IF ascentFlag = 0 {
+		//	The vehicle is going straight up for given amount of time
+		IF TIME:SECONDS >= liftoffTime:SECONDS + controls["verticalAscentTime"] {
+			//	Then it changes attitude for an initial pitchover "kick"
+			SET steeringVector TO aimAndRoll(HEADING(mission["launchAzimuth"], 90-controls["pitchOverAngle"]):VECTOR, steeringRoll).
+			SET ascentFlag TO 1.
+			pushUIMessage( "Pitching over by " + ROUND(controls["pitchOverAngle"], 1) + " degrees." ).
+		}
+	}
+	ELSE IF ascentFlag = 1 {
+		//	It keeps this attitude until velocity vector matches it closely
+		IF TIME:SECONDS < liftoffTime:SECONDS + controls["verticalAscentTime"] + 3 {
+			//	Delay this check for the first few seconds to allow the vehicle to pitch away from current prograde
+		} ELSE {
+			IF controls["pitchOverAngle"] - VANG(SHIP:UP:VECTOR, SHIP:VELOCITY:SURFACE) < 0.1 {
+				SET ascentFlag TO 2.
+			}
+		}
+		//	As a safety check - do not stay deadlocked in this state for too long (might be unnecessary).
+		IF TIME:SECONDS >= liftoffTime:SECONDS + controls["verticalAscentTime"] + SETTINGS["pitchOverTimeLimit"] {
+			SET ascentFlag TO 2.
+			pushUIMessage( "Pitchover time limit exceeded!", 5, PRIORITY_HIGH ).
+		}
+	}
+	ELSE IF ascentFlag = 2 {
+		//	Enter the minimal angle of attack phase. This case is different only in that we push a transition message.
+		SET steeringVector TO minAoASteering(steeringRoll).
+		pushUIMessage( "Holding prograde at " + ROUND(mission["launchAzimuth"], 1) + " deg azimuth." ).
+		SET ascentFlag TO 3.
+	}
+	ELSE {
+		//	Maintain minimal AoA trajectory
+		SET steeringVector TO minAoASteering(steeringRoll).
+	}
+}

--- a/kOS/pegas_atmo.ks
+++ b/kOS/pegas_atmo.ks
@@ -1,14 +1,21 @@
 //	Atmospheric ascent library
 
-//	Basic pitch&hold ascent consists of 4 phases, ascentFlag stores the phase index:
-//	0: vertical ascent
-//	1: pitch over by a given angle
-//	2: hold prograde with a given launch azimuth, emit a UI message
-//	3: hold prograde with a given azimuth
-GLOBAL ascentFlag IS 0.
-
 //	Passive guidance within the atmosphere
 FUNCTION atmosphericSteeringControl {
+	//	Call the appropriate steering controller, depending on vehicle control settings.
+	//	Expects a global variable "controls" as lexicon.
+
+	DECLARE PARAMETER steeringRoll.	//	Expects a scalar
+
+	IF controls:HASKEY("pitchProgram") {
+		pitchProgramControl(steeringRoll).
+	} ELSE {
+		zeroAoAPitchControl(steeringRoll).
+	}
+}
+
+//	Simple pitch over and hold zero angle-of-attack trajectory
+FUNCTION zeroAoAPitchControl {
 	//	Handle the entire atmospheric ascent phase, from vertical ascent, through pitching over,
 	//	to holding prograde at a given azimuth. Called regularly by the main loop, updates the
 	//	steeringVector directly, without returning anything.
@@ -21,6 +28,16 @@ FUNCTION atmosphericSteeringControl {
 	//	"steeringVector" as vector
 
 	DECLARE PARAMETER steeringRoll.	//	Expects a scalar
+
+	//	Define the global at first run
+	IF NOT (DEFINED ascentFlag) {
+		//	Basic pitch&hold ascent consists of 4 phases, ascentFlag stores the phase index:
+		//	0: vertical ascent
+		//	1: pitch over by a given angle
+		//	2: hold prograde with a given launch azimuth, emit a UI message
+		//	3: hold prograde with a given azimuth
+		GLOBAL ascentFlag IS 0.
+	}
 
 	IF ascentFlag = 0 {
 		//	The vehicle is going straight up for given amount of time


### PR DESCRIPTION
This is a refactored and updated version of PR #35 by @Aram1d.

Since I was unable to resolve merge conflicts in his original PR, which also contained several unrelated changes, I decided to manually rewrite Wilfried's code on top of the most current state. This commit, although slightly different, contains only his code (modulo a few minor fixes) and is still authored by him.

Overall, this PR as a whole does something a bit larger than the original PR:
* the entire passive guidance loop has been factored out to a separate new module, `pegas_atmo`
* pitch program configuration has been simplified: now it's a single `pitchProgram` entry
* `control` config checks have been introduced
* slight documentation improvements

This means there are now two ways to control atmospheric ascent:
* the old way, using `verticalAscentTime` and `pitchOverAngle`,
* the new way, using `pitchProgram`.

I'd say this fulfills the requirements described in #9 so...  
Closes #9

Thank you @Aram1d for the contribution, and thank you @Patrykz94 for the original code review!