### PR TITLE
Update to kOS 1.4

### DIFF
--- a/kOS/pegas_cser.ks
+++ b/kOS/pegas_cser.ks
@@ -302,8 +302,8 @@ FUNCTION cse {
 	LOCAL Fts IS -2*b4*D*E.
 	LOCAL Gt IS 1-2*b4*A.
 
-	LOCAL r IS r0m*(F*ir0 + Gs*v0s).
-	LOCAL v IS f2*(Fts*ir0 + Gt*v0s).
+	LOCAL r_ IS r0m*(F*ir0 + Gs*v0s).
+	LOCAL v_ IS f2*(Fts*ir0 + Gt*v0s).
 
-	RETURN LIST(r, v, last).
+	RETURN LIST(r_, v_, last).
 }


### PR DESCRIPTION
Since [kOS v1.4 introduced](https://github.com/KSP-KOS/KOS/blob/develop/CHANGELOG.md#v1400---catch-up-for-over-a-year-of-little-things) some code-breaking changes with respect to variable naming, here's a proposed fix. TL;DR I replaced all occurrences of variables `r`, `v`, `q` and `mass` with underscore-suffixed ones. The script seems to run on my 1.4-updated install.

@Razgriz1 would you mind testing this and confirming?

Closes #49